### PR TITLE
Fix issue when input ('a','b') to isSubsequence

### DIFF
--- a/docs/JavaScript/01/multiplePointers.md
+++ b/docs/JavaScript/01/multiplePointers.md
@@ -132,8 +132,8 @@ isSubsequence('abc', 'acb'); // false (order matters)
   
       let i = 0;
       for (let j = 0; j < str2.length; j++) {
-        if (i == str1.length - 1) return true;
         if (str1[i] === str2[j]) i++;
+        if (i == str1.length) return true; 
       }
   
       return false;


### PR DESCRIPTION
If user input ('a','b') to isSubsequence iterative, it would be return unexpected result. Since `i = 0` now is equal to `str1.length - 1`